### PR TITLE
Use fork instead of process.argv[0]

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,9 @@
+// subcomandante
+var run = require('./index')
+var res = run(['ls', '/']) // will exit with parent.
+
+res.pipe(process.stdout)
+
+setTimeout(function () {
+  process.exit(0)
+}, 200)

--- a/example.js
+++ b/example.js
@@ -1,9 +1,0 @@
-// subcomandante
-var run = require('./index')
-var res = run(['ls', '/']) // will exit with parent.
-
-res.pipe(process.stdout)
-
-setTimeout(function () {
-  process.exit(0)
-}, 200)

--- a/fork.js
+++ b/fork.js
@@ -1,0 +1,45 @@
+var fork = require('child_process').fork
+var duplexer = require('duplexer')
+
+module.exports = function (file, args, opts) {
+  if (Array.isArray(file)) {
+    opts = args
+    args = file.slice(1)
+    file = file[0]
+  }
+
+  opts.silent = true
+
+  var ps = fork(file, args, opts)
+  var err = ''
+  if (ps.stderr) {
+    ps.stderr.on('data', function (buf) { err += buf })
+  }
+
+  ps.on('close', function (code) {
+    if (code === 0) return
+    dup.emit('error', new Error(
+      'non-zero exit code ' + code
+        + (!opts || opts.showCommand !== false
+           ? '\n  while running: ' + file + ' ' + args.join(' ')
+           : ''
+          )
+        + '\n\n  ' + err))
+  })
+
+  var dup = duplexer(ps.stdin, ps.stdout)
+
+  dup.stdin = ps.stdin
+  dup.stderr = ps.stderr
+  dup.stdout = ps.stdout
+  dup.pid = ps.pid
+  dup.kill = ps.kill.bind(ps)
+
+  var exitEvents = ['exit', 'close']
+
+  exitEvents.forEach(function (name) {
+    ps.on(name, dup.emit.bind(dup, name))
+  })
+
+  return dup
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-var comandante = require('comandante')
 var Path = require('path')
+var fork = require('./fork')
 
 var subcom = Path.join(__dirname, 'subcom')
-var node = process.argv[0]
 
 // spawn a child process that will only live
 // as long as its parent. If the parent dies,
@@ -19,8 +18,8 @@ module.exports = function (cmd, args, opts) {
   var w = opts.waitPid || process.pid
   delete opts.waitPid
 
-  args = [subcom, w, cmd].concat(args)
-  var cmd = comandante(node, args, opts)
+  args = [w, cmd].concat(args)
+  var cmd = fork(subcom, args, opts)
 
   // catch SIGKILL and send SIGHUP so subcom kills the child.
   cmd.kill_ = cmd.kill

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/jbenet/node-subcomandante",
   "dependencies": {
     "comandante": "0.0.1",
+    "duplexer": "^0.1.1",
     "is-running": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #2 

There might be a better way to do this, but this effectively a clone of `comandate` in `fork.js` which forks instead of `spawn`s.
