### PR TITLE
Fix issue around exit events

### DIFF
--- a/fork.js
+++ b/fork.js
@@ -17,14 +17,16 @@ module.exports = function (file, args, opts) {
   }
 
   ps.on('close', function (code) {
-    if (code === 0) return
-    dup.emit('error', new Error(
-      'non-zero exit code ' + code
-        + (!opts || opts.showCommand !== false
-           ? '\n  while running: ' + file + ' ' + args.join(' ')
-           : ''
-          )
-        + '\n\n  ' + err))
+    if (code !== 0) {
+      return dup.emit('error', new Error(
+        'non-zero exit code ' + code
+          + (!opts || opts.showCommand !== false
+             ? '\n  while running: ' + file + ' ' + args.join(' ')
+             : ''
+            )
+          + '\n\n  ' + err))
+    }
+    dup.emit('success')
   })
 
   var dup = duplexer(ps.stdin, ps.stdout)


### PR DESCRIPTION
This should fix the issues on this PR -> https://github.com/ipfs/js-ipfsd-ctl/pull/89, according to what's described here https://github.com/ipfs/js-ipfsd-ctl/pull/89#issuecomment-234232228

Basically the current implementation of node-subcomandante may emit an error after the duplex stream closes based on the process exit code. This makes it impossible to know if the process finished successfully or not. To fix it I added another event which is emitted if no error occurred. I named it `success` but let me know if you think we should name it something else.
