### PR TITLE
Listen to `end` event over `finish` for child process stdio

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "comandante": "0.0.1",
     "duplexer": "^0.1.1",
+    "end-of-stream": "^1.4.1",
     "is-running": "^1.0.5"
   },
   "devDependencies": {

--- a/subcom
+++ b/subcom
@@ -51,11 +51,11 @@ child.on('exit', function(code) {
   done.code = code
   exitWhenDone()
 })
-child.stdout.on('finish', function() {
+child.stdout.on('end', function() {
   done.stdout = true
   exitWhenDone()
 })
-child.stderr.on('finish', function() {
+child.stderr.on('end', function() {
   done.stderr = true
   exitWhenDone()
 })

--- a/subcom
+++ b/subcom
@@ -1,6 +1,7 @@
 var isrunning = require('is-running')
 var run = require('comandante')
 var os = require('os')
+var eos = require('end-of-stream')
 
 if (process.argv.length < 4) {
   process.stdout.write('usage: subcom <pid> <cmd>...\n')
@@ -51,11 +52,13 @@ child.on('exit', function(code) {
   done.code = code
   exitWhenDone()
 })
-child.stdout.on('end', function() {
+
+eos(child.stdout, { error: false }, function () {
   done.stdout = true
   exitWhenDone()
 })
-child.stderr.on('end', function() {
+
+eos(child.stderr, { error: false }, function () {
   done.stderr = true
   exitWhenDone()
 })


### PR DESCRIPTION
The `finish` event is documented only for `stream.Writable`, and is not
associated with `stream.Readable` per the stream documentation.

The current behavior appears to be undocumented and recently changed
with in nodejs v9.9.0[0].

[0] https://github.com/nodejs/node/commit/9c0c0e68ac

---------

I opened an issue against nodejs/node, if the issue is closed wontfix, or similar this PR will need to merge to allow for usage on nodejs versions > v9.9.0. This currently affects the ipfs/js-ipfs testing on later versions of nodejs.

https://github.com/nodejs/node/issues/19764